### PR TITLE
Remove challenge field from User

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -158,18 +158,10 @@ is obtained from 3box
 type User @entity {
   "User ethereum address"
   id: ID!
-  "User name"
-  name: String
-  "User bio"
-  bio: String
   "Projects the user owns"
   projects: [Project!] @derivedFrom(field: "owner")
   "Projects the user is a delegate of"
   delegatorProjects: [Project!] @derivedFrom(field: "delegates")
-  "Challenges the user has created"
-  challenges: [Challenge!]
-  "All votes the user has done on any challenge"
-  votes: [Project!]
   "The time the user was created in the Subgraph (not the blockchain)"
   createdAt: Int!
 }

--- a/subgraph/src/mappings/everest.ts
+++ b/subgraph/src/mappings/everest.ts
@@ -111,12 +111,6 @@ export function handleMemberChallenged(event: MemberChallenged): void {
     user = new User(event.params.challenger.toHexString())
     user.createdAt = event.block.timestamp.toI32()
   }
-  let previousChallenges = user.challenges
-  if (previousChallenges == null) {
-    previousChallenges = []
-  }
-  previousChallenges.push(id)
-  user.challenges = previousChallenges
   user.save()
 }
 


### PR DESCRIPTION
This removes challenges and votes from a User. Since these are actually linked to Projects.

It also removes name and bio fields because they are not in use.