### PR TITLE
Add fulltext search field on Project entity

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -183,3 +183,18 @@ type User @entity {
   "The time the user was created in the Subgraph (not the blockchain)"
   createdAt: Int!
 }
+
+type _Schema_ @fulltext(
+  name: "projectSearch"
+  language: en
+  algorithm: rank
+  include: [
+    {
+      entity: "Project",
+      fields: [
+        { name: "name" },
+        { name: "description" },
+      ]
+    }
+  ]
+)


### PR DESCRIPTION
This PR adds a fulltext search field to the subgraph.  The search field is on the Project entity and covers the name and description fields. 

Usage example for the new fulltext query field: 
```graphql
query {
  projectSearch(text: "search text") {
    id
    name 
    description
    website
    twitter
    avatar
  }
}
```