### PR TITLE
Fix resolve challenge bugs

### DIFF
--- a/ui/src/pages/project.js
+++ b/ui/src/pages/project.js
@@ -138,6 +138,7 @@ const Project = ({ location }) => {
   })
 
   const [resolveChallenge] = useMutation(RESOLVE_CHALLENGE, {
+    client: client,
     onError: error => {
       console.error('Error voting on a challenge: ', error)
       setPendingResolve(false)
@@ -981,9 +982,9 @@ const Project = ({ location }) => {
                         This challenge has ended and the project will be{' '}
                         {project.currentChallenge.votesFor >
                         project.currentChallenge.votesAgainst ? (
-                          <span>kept</span>
-                        ) : (
                           <span>removed</span>
+                        ) : (
+                          <span>kept</span>
                         )}
                         . Resolve this challenge to update the registry&apos;s
                         state and earn a reward.

--- a/ui/src/utils/apollo/mutations.js
+++ b/ui/src/utils/apollo/mutations.js
@@ -132,7 +132,6 @@ export const RESOLVE_CHALLENGE = gql`
   mutation resolveChallenge($challengeId: ID!) {
     resolveChallenge(challengeId: $challengeId) @client {
       id
-      description
     }
   }
 `


### PR DESCRIPTION
The bug was happening because we weren't passing `client`

The other bug is that kept and removed had to be reversed. Un-intuitively, when votesFor are larger, it means you are voting them OFF the list, and therefore the project is being removed