### PR TITLE
Sorting by date - recent first

### DIFF
--- a/ui/src/components/Sorting/index.js
+++ b/ui/src/components/Sorting/index.js
@@ -75,15 +75,14 @@ const Sorting = ({
       </Grid>
     ),
     handleSelect: () => {
-      if (selectedOrderBy === orderBy[order]) {
-        setSelectedOrderDirection(
+      if (selectedOrderBy !== orderBy[order]) {
+        setSelectedOrderBy(orderBy[order])
+      },
+      setSelectedOrderDirection(
           selectedOrderDirection === ORDER_DIRECTION.ASC
             ? ORDER_DIRECTION.DESC
             : ORDER_DIRECTION.ASC,
         )
-      } else {
-        setSelectedOrderBy(orderBy[order])
-      }
     },
     delay: 500,
   }))


### PR DESCRIPTION
Because the ASC / DESC preference of by name versus by date date is inverse, it should always trigger switching the selectedOrderDirection