### PR TITLE
Keep project sorting after navigation

### DIFF
--- a/ui/src/pages/projects.js
+++ b/ui/src/pages/projects.js
@@ -31,9 +31,11 @@ const Projects = ({ location }) => {
     queryParams && queryParams.view ? queryParams.view : FILTERS.all,
   )
   const [isFilterOpen, setIsFilterOpen] = useState(false)
-  const [selectedOrderBy, setSelectedOrderBy] = useState(ORDER_BY['Name'])
+  const [selectedOrderBy, setSelectedOrderBy] = useState(
+    selectedOrderBy ? selectedOrderBy : ORDER_BY['Name']
+  )
   const [selectedOrderDirection, setSelectedOrderDirection] = useState(
-    ORDER_DIRECTION.ASC,
+    selectedOrderDirection ? selectedOrderDirection : ORDER_DIRECTION.ASC,
   )
   const [isSortingOpen, setIsSortingOpen] = useState(false)
 


### PR DESCRIPTION
If selectedOrderBy is defined, use it, else initialise with 'name'.
If selectedOrderDirection is defined, used it, else initialise with ascending.