### PR TITLE
Obscure bug because of a project without a category

### DIFF
--- a/ui/src/components/Search/index.js
+++ b/ui/src/components/Search/index.js
@@ -166,7 +166,7 @@ const Search = ({ isSearchOpen, setIsSearchOpen, value, setValue }) => {
                   variant="project"
                   image={project.avatar}
                   to={`/project/${project.id}`}
-                  category={project.categories[0] ? project.categories[0].name : "None"}
+                  category={project.categories?.[0]?.name ?? 'None'}
                   isChallenged={project.isChallenged}
                 />
               ))}

--- a/ui/src/components/Search/index.js
+++ b/ui/src/components/Search/index.js
@@ -166,7 +166,7 @@ const Search = ({ isSearchOpen, setIsSearchOpen, value, setValue }) => {
                   variant="project"
                   image={project.avatar}
                   to={`/project/${project.id}`}
-                  category={project.categories[0].name}
+                  category={project.categories[0] ? project.categories[0].name : "None"}
                   isChallenged={project.isChallenged}
                 />
               ))}


### PR DESCRIPTION
There is currently a project on everest without a category, if it turns up as a result on any search, it completely breaks the interface.
The project is OriginTrail : https://everest.link/project/0xdda698603dea5595f901136a4fde5e7993ded57b/

The bug was found by this user : https://github.com/graphprotocol/mission-control-curator/issues/9

I know this is not supposed to happen as every project is required to have a category, but until we figure out how that happened it might be a good idea to implement this ad interim.