### PR TITLE
Fix absolute URL being interpreted as relative

### DIFF
--- a/ui/src/pages/project/template.js
+++ b/ui/src/pages/project/template.js
@@ -538,8 +538,9 @@ const Project = ({ location }) => {
     tweet = `We’d like to claim the ${project.name} project on @EverestRegistry. Please transfer ownership to ${account} 🙌`
   }
   
-  if (project.website && !project.website.startsWith('http'))
+  if (project.website && !project.website.startsWith('http')) {
     project.website = 'http://' + project.website
+  }
   
   let items = []
 

--- a/ui/src/pages/project/template.js
+++ b/ui/src/pages/project/template.js
@@ -538,7 +538,7 @@ const Project = ({ location }) => {
     tweet = `We’d like to claim the ${project.name} project on @EverestRegistry. Please transfer ownership to ${account} 🙌`
   }
   
-  if (project.website && !project.website.includes('http'))
+  if (project.website && !project.website.startsWith('http'))
     project.website = 'http://' + project.website
   
   let items = []

--- a/ui/src/pages/project/template.js
+++ b/ui/src/pages/project/template.js
@@ -537,7 +537,10 @@ const Project = ({ location }) => {
   if (project) {
     tweet = `We’d like to claim the ${project.name} project on @EverestRegistry. Please transfer ownership to ${account} 🙌`
   }
-
+  
+  if (project.website && !project.website.includes('http'))
+    project.website = 'http://' + project.website
+  
   let items = []
 
   if (account && project && project.owner && account === project.owner.id) {


### PR DESCRIPTION
There is a bug where users that submit URLs without appending "https" or "http", the urls are interpreted as relative.

This commit checks this in the front-end and replaces the project URL correctly in all occurrences within the page.

The bug in question was found here : https://github.com/graphprotocol/mission-control-curator/issues/10

