### PR TITLE
Fix bug of missing data after project submission

### DIFF
--- a/ui/src/pages/profile.js
+++ b/ui/src/pages/profile.js
@@ -132,10 +132,11 @@ const Profile = ({ location }) => {
       endTime: moment().unix(),
       projects:
         data && data.user
-          ? data.user.projects.reduce(
-              (acc, current) => acc.concat(current.id),
-              [],
-            )
+          ? data.user.projects.reduce((acc, current) => {
+            if(current) {
+              return acc.concat(current.id)
+            }
+          }, [])
           : [],
     },
   })


### PR DESCRIPTION
Once a project is submitted, the page goes blank, after looking it up it was from the array.reduce trying to access .id of a null value. I couldn't further test any other errors that might be caused through this since it requires a tx confirmation. Will look more into it and see if there's more potential issues.