### PR TITLE
Fix image uploading to IPFS when creating a new project

### DIFF
--- a/subgraph/mutations/src/utils.ts
+++ b/subgraph/mutations/src/utils.ts
@@ -4,9 +4,7 @@ export const uploadToIpfs = async (ipfs: any, data: any): Promise<string> => {
   let result
 
   try {
-    for await (const returnedValue of ipfs.add(data)) {
-      result = returnedValue
-    }
+    result = await ipfs.add(data)
   } catch (e) {
     console.log('ipfs error: ', e)
   }


### PR DESCRIPTION
A change in our IPFS API broke image uploading. This change should fix the issue.