### PR TITLE
Update everest-contracts references to new npm package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     ]
   },
   "scripts": {
-    "build:contracts": "lerna exec --scope everest-contracts -- yarn build",
+    "build:contracts": "lerna exec --scope @graphprotocol/everest-contracts -- yarn build",
     "build:mutations": "lerna exec --scope everest-mutations -- yarn build",
     "build:subgraph-ropsten": "lerna exec --scope everest-subgraph -- yarn build-ropsten",
     "build:subgraph-mainnet": "lerna exec --scope everest-subgraph -- yarn build-mainnet",

--- a/subgraph/mutations/src/contract-helpers/daiPermit.ts
+++ b/subgraph/mutations/src/contract-helpers/daiPermit.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 
-const addresses = require('everest-contracts/addresses.json')
+const addresses = require('@graphprotocol/everest-contracts/addresses.json')
 
 //////////////////////////
 //////// DAI utils ///////

--- a/subgraph/mutations/src/index.ts
+++ b/subgraph/mutations/src/index.ts
@@ -123,18 +123,19 @@ const sendTransaction = async (tx: Promise<Transaction>) => {
 }
 
 const abis = {
-  Context: require('everest-contracts/abis/Context.json').abi,
-  Dai: require('everest-contracts/abis/Dai.json').abi,
-  EthereumDIDRegistry: require('everest-contracts/abis/EthereumDIDRegistry.json').abi,
-  LibNote: require('everest-contracts/abis/LibNote.json').abi,
-  Ownable: require('everest-contracts/abis/Ownable.json').abi,
-  Registry: require('everest-contracts/abis/Registry.json').abi,
-  ReserveBank: require('everest-contracts/abis/ReserveBank.json').abi,
-  SafeMath: require('everest-contracts/abis/SafeMath.json').abi,
-  Everest: require('everest-contracts/abis/Everest.json').abi,
+  Context: require('@graphprotocol/everest-contracts/abis/Context.json').abi,
+  Dai: require('@graphprotocol/everest-contracts/abis/Dai.json').abi,
+  EthereumDIDRegistry: require('@graphprotocol/everest-contracts/abis/EthereumDIDRegistry.json')
+    .abi,
+  LibNote: require('@graphprotocol/everest-contracts/abis/LibNote.json').abi,
+  Ownable: require('@graphprotocol/everest-contracts/abis/Ownable.json').abi,
+  Registry: require('@graphprotocol/everest-contracts/abis/Registry.json').abi,
+  ReserveBank: require('@graphprotocol/everest-contracts/abis/ReserveBank.json').abi,
+  SafeMath: require('@graphprotocol/everest-contracts/abis/SafeMath.json').abi,
+  Everest: require('@graphprotocol/everest-contracts/abis/Everest.json').abi,
 }
 
-const addresses = require('everest-contracts/addresses.json')
+const addresses = require('@graphprotocol/everest-contracts/addresses.json')
 
 const addressMap = {
   Dai: 'dai',


### PR DESCRIPTION
Previously we were referencing a `everest-contracts` npm package. This got removed in the past causing builds to break. We now publish the new package at `@graphprotocol/everest` and this PR updates our references to point to this dependency.